### PR TITLE
feat: add open3d vendor package

### DIFF
--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(open3d_vendor REQUIRED)
 find_package(Open3D REQUIRED)
 
 find_package(rclcpp REQUIRED)

--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -15,6 +15,7 @@
   <author email="nkhedekar@nevada.unr.edu">Nikhil Khedekar</author>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>open3d_vendor</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>eigen</depend>

--- a/open3d_vendor/CMakeLists.txt
+++ b/open3d_vendor/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(open3d_vendor)
+
+find_package(ament_cmake REQUIRED)
+
+option(FORCE_BUILD_VENDOR_PKG
+  "Build open3d from source, even if system-installed package is available"
+  OFF)
+
+if(NOT FORCE_BUILD_VENDOR_PKG)
+  find_package(Open3D QUIET)
+endif()
+
+macro(build_open3d)
+  set(extra_cmake_args)
+
+  include(ExternalProject)
+  externalproject_add(open3d-0.15.1
+    GIT_REPOSITORY https://github.com/isl-org/Open3D.git
+    GIT_TAG ed30e3b61fbe031e106fa64030bec3f698b316b4  # v0.15.1
+    UPDATE_COMMAND ""
+    TIMEOUT 300
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+      -DCMAKE_INSTALL_INCLUDEDIR=include/${PROJECT_NAME}
+      -DBUILD_SHARED_LIBS=ON
+      -DBUILD_EXAMPLES=OFF
+      -DBUILD_PYTHON_MODULE=OFF
+  )
+
+  # The external project will install to the build folder, but we'll install that on make install.
+  install(
+    DIRECTORY
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}
+    USE_SOURCE_PERMISSIONS
+  )
+endmacro()
+
+if(NOT Open3D_FOUND)
+  build_open3d()
+endif()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/open3d_vendor/package.xml
+++ b/open3d_vendor/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>open3d_vendor</name>
+  <version>0.1.0</version>
+  <description>The vendor package for Open3D</description>
+
+  <maintainer email="nishimarudai@gmail.com">Daisuke Nishimatsu</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <author email="nishimarudai@gmail.com">Daisuke Nishimatsu</author>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
+
+  <depend>libx11</depend>
+  <depend>libxcursor-dev</depend>
+  <depend>libxi-dev</depend>
+  <depend>libxinerama-dev</depend>
+  <depend>libxrandr</depend>
+  <depend>opengl</depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Currently, open3d apt package is not available. I added a vendor package to build open3d from src.