### PR TITLE
fix: add open3d dependency into package.xml

### DIFF
--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -15,6 +15,7 @@
   <author email="nkhedekar@nevada.unr.edu">Nikhil Khedekar</author>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>libopen3d-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
add open3d dependecy because `libopen3d-dev` is available as apt package on jammy.