### PR TITLE
Add open3d::geometry::Image <-> sensor_msgs::msg::Image conversions

### DIFF
--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Eigen3 REQUIRED)
 find_package(Open3D REQUIRED)
 
 find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(
@@ -28,6 +29,7 @@ target_include_directories(open3d_conversions PUBLIC
 ament_target_dependencies(
   open3d_conversions
   "rclcpp"
+  "rcpputils"
   "sensor_msgs"
 )
 target_link_libraries(open3d_conversions ${Open3D_LIBRARIES})

--- a/open3d_conversions/README.md
+++ b/open3d_conversions/README.md
@@ -1,6 +1,6 @@
 # open3d_conversions
 
-This package provides functions that can convert pointclouds from ROS to Open3D and vice-versa.
+This package provides functions that can convert pointclouds and images from ROS to Open3D and vice-versa.
 
 ## Dependencies
 
@@ -21,18 +21,64 @@ This package provides functions that can convert pointclouds from ROS to Open3D 
 
 * In case you are building this package from source, time taken for the conversion functions will be much larger if it is not built in `Release` mode.
 
-## Usage
+## Pointcloud Conversion
 
-There are two functions provided in this library:
+There are two pointcloud conversion functions provided in this library:
 
 ```cpp
-void open3d_conversions::open3dToRos(const open3d::geometry::PointCloud & pointcloud, sensor_msgs::msg::PointCloud2 & ros_pc2, std::string frame_id = "open3d_pointcloud");
+void open3d_conversions::open3dToRos(
+  const open3d::geometry::PointCloud & pointcloud,
+  sensor_msgs::msg::PointCloud2 & ros_pc2, 
+  std::string frame_id = "open3d_pointcloud");
 
-void open3d_conversions::rosToOpen3d(const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2, open3d::geometry::PointCloud & o3d_pc, bool skip_colors=false);
+void open3d_conversions::rosToOpen3d(
+  const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2,
+  open3d::geometry::PointCloud & o3d_pc, 
+  bool skip_colors=false);
 ```
 
 * As Open3D pointclouds only contain `points`, `colors` and `normals`, the interface currently supports XYZ, XYZRGB pointclouds. XYZI pointclouds are handled by placing the `intensity` value in the `colors_`.
 * On creating a ROS pointcloud from an Open3D pointcloud, the user is expected to set the timestamp in the header and pass the `frame_id` to the conversion function.
+
+## Image Conversion
+
+There are four image conversion functions provided in this library:
+
+```cpp
+void open3dToRos(
+  const open3d::geometry::Image & o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id = "open3d_image");
+
+void open3dToRos(
+  const open3d::camera::PinholeCameraIntrinsic & intrinsic,
+  sensor_msgs::msg::CameraInfo & camera_info,
+  std::string frame_id = "open3d_image");
+
+void rosToOpen3d(
+  const sensor_msgs::msg::Image & ros_img,
+  open3d::geometry::Image & o3d_img);
+
+void rosToOpen3d(
+  const sensor_msgs::msg::CameraInfo & camera_info,
+  open3d::camera::PinholeCameraIntrinsic & intrinsic);
+```
+Additionally, two explicit move-only versions of the image conversions are provided for efficiency:
+
+```cpp
+void moveOpen3dToRos(
+  open3d::geometry::Image && o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id = "open3d_image");
+
+void moveRosToOpen3d(
+  sensor_msgs::msg::Image && ros_img,
+  open3d::geometry::Image & o3d_img);
+```
+
+* As Open3D only stores camera info as a pinhole camera model, distorsion information cannot be inferred from an Open3D -> ROS conversion. Such a conversions sets the distorsion model to "plumb_bob" with all five **D** parameters equal to zero.
 
 ## Documentation
 

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -18,6 +18,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
 
 // Open3D
 #include <open3d/Open3D.h>
@@ -49,14 +50,31 @@ void open3dToRos(
  * @brief Copy data from a open3d::geometry::Image to a 
  * sensor_msgs::msg::Image
  * 
- * @param image Forwarding reference to the open3d geometry Image
- * @param ros_img Reference to teh sensor_msgs Image
+ * @param image Reference to the open3d geometry Image
+ * @param ros_img Reference to the sensor_msgs Image
+ * @param encoding The encoding of the image to use in ROS format
  * @param frame_id The string to be placed in the frame_id of the Image
  */
 void open3dToRos(
   const open3d::geometry::Image & o3d_img,
   sensor_msgs::msg::Image & ros_img,
   std::string encoding,
+  std::string frame_id = "open3d_image");
+
+/**
+ * @brief Copy data from a open3d::camera::PinholeCameraIntrinsic
+ * to a sensor_msgs::msg::CameraInfo
+ * 
+ * @param intrinsic Reference to the camera intrinsic in open3d format 
+ * @param ros_img Reference to the sensor_msgs CameraInfo
+ * @param frame_id The string to be placed in the frame_id of the Image
+ * 
+ * @note Open3D does not record distortion parameters for its images, so
+ * the sensor_msgs Image be labelled as "plumb_bob" with D values of 0
+ */
+void open3dToRos(
+  const open3d::camera::PinholeCameraIntrinsic & intrinsic,
+  sensor_msgs::msg::CameraInfo & camera_info,
   std::string frame_id = "open3d_image");
 
 /**
@@ -80,7 +98,50 @@ void rosToOpen3d(
  * @param o3d_img Reference to the open3d geometry Image
  */
 void rosToOpen3d(
-  const sensor_msgs::msg::Image::SharedPtr ros_img,
+  const sensor_msgs::msg::Image & ros_img,
+  open3d::geometry::Image & o3d_img);
+
+/**
+ * @brief Copy data from a sensor_msgs::msg::CameraInfo
+ * to a open3d::camera::PinholeCameraIntrinsic
+ * 
+ * @param ros_img Reference to the sensor_msgs CameraInfo to populate
+ * @param intrinsic Reference to the open3d PinholeCameraIntrinsic 
+ */
+void rosToOpen3d(
+  const sensor_msgs::msg::CameraInfo & camera_info,
+  open3d::camera::PinholeCameraIntrinsic & intrinsic);
+
+/**
+ * @brief Move data from a open3d::geometry::Image to a
+ * sensor_msgs::msg::Image
+ * 
+ * @param o3d_img Reference to the open3d geometry Image
+ * @param ros_img Reference to the sensor_msgs Image
+ * @param encoding The encoding of the image to use in ROS format
+ * @param frame_id The string to be placed in the frame_id of the Image
+ * 
+ * @note The Open3D image will be in a well defined state after this
+ * operation with width = height = 0, and an empty data vector
+ */
+void moveOpen3dToRos(
+  open3d::geometry::Image && o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id = "open3d_image");
+
+/**
+ * @brief Move data from a sensor_msgs::msg::Image to a
+ * open3d::geometry::Image
+ * 
+ * @param ros_img Reference to the sensor_msgs Image
+ * @param o3d_img Reference to the open3d geometry Image
+ * 
+ * @note The sensor_msgs Image will be a well defined state after this
+ * operation with width = height = 0, and an empty data vector
+ */
+void moveRosToOpen3d(
+  sensor_msgs::msg::Image && ros_img,
   open3d::geometry::Image & o3d_img);
 
 }  // namespace open3d_conversions

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -35,11 +35,11 @@ namespace open3d_conversions
 {
 /**
  * @brief Copy data from a open3d::geometry::PointCloud to a
- * sensor_msgs::msg::PointCloud2
+ * sensor_msgs::msg::PointCloud2. The header field of the output
+ * pointcloud is not modified, and must be filled out separately
  *
  * @param pointcloud Reference to the open3d geometry PointCloud
  * @param ros_pc2 Reference to the sensor_msgs PointCloud2
- * @param frame_id The string to be placed in the frame_id of the PointCloud2
  */
 void open3dToRos(
   const open3d::geometry::PointCloud & pointcloud,
@@ -47,12 +47,12 @@ void open3dToRos(
 
 /**
  * @brief Copy data from a open3d::geometry::Image to a
- * sensor_msgs::msg::Image
+ * sensor_msgs::msg::Image. The header field of the output
+ * image is not modified, and must be filled out separately
  *
  * @param image Reference to the open3d geometry Image
  * @param ros_img Reference to the sensor_msgs Image
  * @param encoding The encoding of the image to use in ROS format
- * @param frame_id The string to be placed in the frame_id of the Image
  */
 void open3dToRos(
   const open3d::geometry::Image & o3d_img,
@@ -61,11 +61,11 @@ void open3dToRos(
 
 /**
  * @brief Copy data from a open3d::camera::PinholeCameraIntrinsic
- * to a sensor_msgs::msg::CameraInfo
+ * to a sensor_msgs::msg::CameraInfo. The header field of the output
+ * camera info is not modified, and must be filled out separately
  *
  * @param intrinsic Reference to the camera intrinsic in open3d format
  * @param ros_img Reference to the sensor_msgs CameraInfo
- * @param frame_id The string to be placed in the frame_id of the Image
  *
  * @note Open3D does not record distortion parameters for its images, so
  * the sensor_msgs Image be labelled as "plumb_bob" with D values of 0
@@ -111,12 +111,12 @@ void rosToOpen3d(
 
 /**
  * @brief Move data from a open3d::geometry::Image to a
- * sensor_msgs::msg::Image
+ * sensor_msgs::msg::Image. The header field of the output
+ * image is not modified, and must be filled out separately
  *
  * @param o3d_img Reference to the open3d geometry Image
  * @param ros_img Reference to the sensor_msgs Image
  * @param encoding The encoding of the image to use in ROS format
- * @param frame_id The string to be placed in the frame_id of the Image
  *
  * @note The Open3D image will be in a well defined state after this
  * operation with width = height = 0, and an empty data vector

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -14,20 +14,20 @@
 #ifndef OPEN3D_CONVERSIONS__OPEN3D_CONVERSIONS_HPP_
 #define OPEN3D_CONVERSIONS__OPEN3D_CONVERSIONS_HPP_
 
+// Eigen
+#include <Eigen/Dense>
+
+// Open3D
+#include <open3d/Open3D.h>
+
+// C++
+#include <string>
+
 // ROS2
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-
-// Open3D
-#include <open3d/Open3D.h>
-
-// Eigen
-#include <Eigen/Dense>
-
-// C++
-#include <string>
 
 #include "open3d_conversions/visibility_control.h"
 
@@ -47,9 +47,9 @@ void open3dToRos(
   std::string frame_id = "open3d_pointcloud");
 
 /**
- * @brief Copy data from a open3d::geometry::Image to a 
+ * @brief Copy data from a open3d::geometry::Image to a
  * sensor_msgs::msg::Image
- * 
+ *
  * @param image Reference to the open3d geometry Image
  * @param ros_img Reference to the sensor_msgs Image
  * @param encoding The encoding of the image to use in ROS format
@@ -64,11 +64,11 @@ void open3dToRos(
 /**
  * @brief Copy data from a open3d::camera::PinholeCameraIntrinsic
  * to a sensor_msgs::msg::CameraInfo
- * 
- * @param intrinsic Reference to the camera intrinsic in open3d format 
+ *
+ * @param intrinsic Reference to the camera intrinsic in open3d format
  * @param ros_img Reference to the sensor_msgs CameraInfo
  * @param frame_id The string to be placed in the frame_id of the Image
- * 
+ *
  * @note Open3D does not record distortion parameters for its images, so
  * the sensor_msgs Image be labelled as "plumb_bob" with D values of 0
  */
@@ -104,9 +104,9 @@ void rosToOpen3d(
 /**
  * @brief Copy data from a sensor_msgs::msg::CameraInfo
  * to a open3d::camera::PinholeCameraIntrinsic
- * 
+ *
  * @param ros_img Reference to the sensor_msgs CameraInfo to populate
- * @param intrinsic Reference to the open3d PinholeCameraIntrinsic 
+ * @param intrinsic Reference to the open3d PinholeCameraIntrinsic
  */
 void rosToOpen3d(
   const sensor_msgs::msg::CameraInfo & camera_info,
@@ -115,12 +115,12 @@ void rosToOpen3d(
 /**
  * @brief Move data from a open3d::geometry::Image to a
  * sensor_msgs::msg::Image
- * 
+ *
  * @param o3d_img Reference to the open3d geometry Image
  * @param ros_img Reference to the sensor_msgs Image
  * @param encoding The encoding of the image to use in ROS format
  * @param frame_id The string to be placed in the frame_id of the Image
- * 
+ *
  * @note The Open3D image will be in a well defined state after this
  * operation with width = height = 0, and an empty data vector
  */
@@ -133,10 +133,10 @@ void moveOpen3dToRos(
 /**
  * @brief Move data from a sensor_msgs::msg::Image to a
  * open3d::geometry::Image
- * 
+ *
  * @param ros_img Reference to the sensor_msgs Image
  * @param o3d_img Reference to the open3d geometry Image
- * 
+ *
  * @note The sensor_msgs Image will be a well defined state after this
  * operation with width = height = 0, and an empty data vector
  */

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -1,11 +1,11 @@
 // Copyright 2020 Autonomous Robots Lab, University of Nevada, Reno
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -43,8 +43,7 @@ namespace open3d_conversions
  */
 void open3dToRos(
   const open3d::geometry::PointCloud & pointcloud,
-  sensor_msgs::msg::PointCloud2 & ros_pc2,
-  std::string frame_id = "open3d_pointcloud");
+  sensor_msgs::msg::PointCloud2 & ros_pc2);
 
 /**
  * @brief Copy data from a open3d::geometry::Image to a
@@ -58,8 +57,7 @@ void open3dToRos(
 void open3dToRos(
   const open3d::geometry::Image & o3d_img,
   sensor_msgs::msg::Image & ros_img,
-  std::string encoding,
-  std::string frame_id = "open3d_image");
+  std::string encoding);
 
 /**
  * @brief Copy data from a open3d::camera::PinholeCameraIntrinsic
@@ -74,8 +72,7 @@ void open3dToRos(
  */
 void open3dToRos(
   const open3d::camera::PinholeCameraIntrinsic & intrinsic,
-  sensor_msgs::msg::CameraInfo & camera_info,
-  std::string frame_id = "open3d_image");
+  sensor_msgs::msg::CameraInfo & camera_info);
 
 /**
  * @brief Copy data from a sensor_msgs::msg::PointCloud2 to a
@@ -127,8 +124,7 @@ void rosToOpen3d(
 void moveOpen3dToRos(
   open3d::geometry::Image && o3d_img,
   sensor_msgs::msg::Image & ros_img,
-  std::string encoding,
-  std::string frame_id = "open3d_image");
+  std::string encoding);
 
 /**
  * @brief Move data from a sensor_msgs::msg::Image to a

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -17,6 +17,7 @@
 // ROS2
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 // Open3D
 #include <open3d/Open3D.h>
@@ -43,6 +44,21 @@ void open3dToRos(
   const open3d::geometry::PointCloud & pointcloud,
   sensor_msgs::msg::PointCloud2 & ros_pc2,
   std::string frame_id = "open3d_pointcloud");
+
+/**
+ * @brief Copy data from a open3d::geometry::Image to a 
+ * sensor_msgs::msg::Image
+ * 
+ * @param image Forwarding reference to the open3d geometry Image
+ * @param ros_img Reference to teh sensor_msgs Image
+ * @param frame_id The string to be placed in the frame_id of the Image
+ */
+void open3dToRos(
+  const open3d::geometry::Image & o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id = "open3d_image");
+
 /**
  * @brief Copy data from a sensor_msgs::msg::PointCloud2 to a
  * open3d::geometry::PointCloud
@@ -55,6 +71,17 @@ void rosToOpen3d(
   const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2,
   open3d::geometry::PointCloud & o3d_pc,
   bool skip_colors = false);
+
+/**
+ * @brief Copy data from a sensor_msgs::msg::Image to a
+ * open3d::geometry::Image
+ *
+ * @param ros_img Reference to the sensor_msgs Image
+ * @param o3d_img Reference to the open3d geometry Image
+ */
+void rosToOpen3d(
+  const sensor_msgs::msg::Image::SharedPtr ros_img,
+  open3d::geometry::Image & o3d_img);
 
 }  // namespace open3d_conversions
 

--- a/open3d_conversions/include/open3d_conversions/visibility_control.h
+++ b/open3d_conversions/include/open3d_conversions/visibility_control.h
@@ -1,16 +1,17 @@
 // Copyright 2020 Autonomous Robots Lab, University of Nevada, Reno
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #ifndef OPEN3D_CONVERSIONS__VISIBILITY_CONTROL_H_
 #define OPEN3D_CONVERSIONS__VISIBILITY_CONTROL_H_
 

--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -17,6 +17,7 @@
 
   <depend>libopen3d-dev</depend>
   <depend>rclcpp</depend>
+  <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
   <depend>eigen</depend>
 

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -51,7 +51,7 @@ namespace open3d_conversions
 {
 void open3dToRos(
   const open3d::geometry::PointCloud & pointcloud,
-  sensor_msgs::msg::PointCloud2 & ros_pc2, std::string frame_id)
+  sensor_msgs::msg::PointCloud2 & ros_pc2)
 {
   sensor_msgs::PointCloud2Modifier modifier(ros_pc2);
   if (pointcloud.HasColors()) {
@@ -60,7 +60,6 @@ void open3dToRos(
     modifier.setPointCloud2FieldsByString(1, "xyz");
   }
   modifier.resize(pointcloud.points_.size());
-  ros_pc2.header.frame_id = frame_id;
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_x(ros_pc2, "x");
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_y(ros_pc2, "y");
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_z(ros_pc2, "z");
@@ -96,12 +95,10 @@ void open3dToRos(
 void open3dToRos(
   const open3d::geometry::Image & o3d_img,
   sensor_msgs::msg::Image & ros_img,
-  std::string encoding,
-  std::string frame_id)
+  std::string encoding)
 {
   checkEncodingValidity(encoding, o3d_img);
   ros_img.encoding = encoding;
-  ros_img.header.frame_id = frame_id;
   ros_img.height = o3d_img.height_;
   ros_img.width = o3d_img.width_;
   ros_img.step = o3d_img.BytesPerLine();
@@ -111,8 +108,7 @@ void open3dToRos(
 
 void open3dToRos(
   const open3d::camera::PinholeCameraIntrinsic & intrinsic,
-  sensor_msgs::msg::CameraInfo & camera_info,
-  std::string frame_id)
+  sensor_msgs::msg::CameraInfo & camera_info)
 {
   // Intrinsic matrix is 3x3 row-major
   std::fill(camera_info.k.begin(), camera_info.k.end(), 0.0);
@@ -237,12 +233,10 @@ void rosToOpen3d(
 void moveOpen3dToRos(
   open3d::geometry::Image && o3d_img,
   sensor_msgs::msg::Image & ros_img,
-  std::string encoding,
-  std::string frame_id)
+  std::string encoding)
 {
   checkEncodingValidity(encoding, o3d_img);
   ros_img.encoding = encoding;
-  ros_img.header.frame_id = frame_id;
   ros_img.height = o3d_img.height_;
   ros_img.width = o3d_img.width_;
   ros_img.step = o3d_img.BytesPerLine();

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -33,7 +33,7 @@ static void checkEncodingValidity(
     std::stringstream ss;
     ss << "Mismatch between Open3D image encoding and desired embedded encoding"
        << "You asked for \"" << encoding << "\" which has " << expected_num_channels
-       << "channels but the provided image had " << o3d_img.num_of_channels_ << " channels";
+       << " channels but the provided image had " << o3d_img.num_of_channels_ << " channels";
     throw std::runtime_error(ss.str());
   }
 
@@ -41,7 +41,7 @@ static void checkEncodingValidity(
     std::stringstream ss;
     ss << "Mismatch between Open3D image encoding and desired embedded encoding"
        << "You asked for \"" << encoding << "\" which has " << expected_bytes_per_channel
-       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_
+       << " bytes per channel but the provided image had " << o3d_img.bytes_per_channel_
        << " bytes per channel";
     throw std::runtime_error(ss.str());
   }

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -185,13 +185,40 @@ void rosToOpen3d(
   const sensor_msgs::msg::Image & ros_img,
   open3d::geometry::Image & o3d_img)
 {
+  const int num_channels = sensor_msgs::image_encodings::numChannels(ros_img.encoding);
+  const int bytes_per_channel = sensor_msgs::image_encodings::bitDepth(ros_img.encoding) / 8;
+
   o3d_img.Prepare(
     ros_img.width,
     ros_img.height,
-    sensor_msgs::image_encodings::numChannels(ros_img.encoding),
-    sensor_msgs::image_encodings::bitDepth(ros_img.encoding) / 8
+    num_channels,
+    bytes_per_channel
   );
-  o3d_img.data_ = ros_img.data;
+
+  // Open3D requires the image to be in native endianness
+  if (ros_img.is_bigendian && rcpputils::endian::native == rcpputils::endian::big ||
+    !ros_img.is_bigendian && rcpputils::endian::native == rcpputils::endian::little ||
+    bytes_per_channel == 1)
+  {
+    o3d_img.data_ = ros_img.data;
+    return;
+  }
+
+  // Otherwise, flip the bytes of each channel entry
+  o3d_img.data_.clear();
+  o3d_img.data_.reserve(ros_img.data.size());
+  const std::ptrdiff_t data_step = bytes_per_channel * num_channels;
+  for (auto data_ptr = ros_img.data.begin(); data_ptr != ros_img.data.end();
+    std::advance(data_ptr, data_step))
+  {
+    for (std::ptrdiff_t channel_idx = 0; channel_idx < num_channels; ++channel_idx) {
+      const std::ptrdiff_t channel_start = channel_idx * bytes_per_channel;
+      for (std::ptrdiff_t byte_idx = 0; byte_idx < bytes_per_channel; ++byte_idx) {
+        const std::ptrdiff_t reverse_byte_idx = bytes_per_channel - byte_idx - 1;
+        o3d_img.data_.push_back(*(data_ptr + channel_start + reverse_byte_idx));
+      }
+    }
+  }
 }
 
 void rosToOpen3d(
@@ -230,6 +257,15 @@ void moveRosToOpen3d(
   sensor_msgs::msg::Image && ros_img,
   open3d::geometry::Image & o3d_img)
 {
+  // If the endianness does not match, we will need to perform a copy anyway
+  if ((ros_img.is_bigendian && rcpputils::endian::native == rcpputils::endian::little ||
+    !ros_img.is_bigendian && rcpputils::endian::native == rcpputils::endian::big) &&
+    sensor_msgs::image_encodings::bitDepth(ros_img.encoding) > 8)
+  {
+    rosToOpen3d(ros_img, o3d_img);
+    return;
+  }
+
   o3d_img.Prepare(
     ros_img.width,
     ros_img.height,

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -1,11 +1,11 @@
 // Copyright 2020 Autonomous Robots Lab, University of Nevada, Reno
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -15,8 +15,18 @@
 // C++
 #include <memory>
 #include <string>
+#include <sstream>
 
+#include <sensor_msgs/image_encodings.hpp>
 #include "open3d_conversions/open3d_conversions.hpp"
+
+// This is the best we have prior to C++20 std::endian::native
+static bool isLittleEndian(){
+  const int32_t value = 0x01;
+  const std::byte * least_significant_address = 
+    reinterpret_cast<const std::byte *>(&value);
+  return (*least_significant_address == std::byte{0x01});
+}
 
 namespace open3d_conversions
 {
@@ -62,6 +72,42 @@ void open3dToRos(
       *ros_pc2_z = point(2);
     }
   }
+}
+
+void open3dToRos(
+  const open3d::geometry::Image & o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id)
+{
+  const int expected_num_channels = sensor_msgs::image_encodings::numChannels(encoding);
+  const int expected_bytes_per_channel = sensor_msgs::image_encodings::bitDepth(encoding)/8;
+
+  // Verify that the encoding makes sense with the given image
+  if (expected_num_channels != o3d_img.num_of_channels_){
+    std::stringstream ss;
+    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
+       << "You asked for \"" << encoding << "\" which has " << expected_num_channels
+       << "channels but the provided image had " << o3d_img.num_of_channels_ << " channels";
+    throw std::runtime_error(ss.str());
+  }
+
+  if (expected_bytes_per_channel != o3d_img.bytes_per_channel_){
+    std::stringstream ss;
+    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
+       << "You asked for \"" << encoding << "\" which has " << expected_bytes_per_channel
+       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_ 
+       << " bytes per channel";
+    throw std::runtime_error(ss.str());
+  }
+
+  ros_img.encoding = encoding;
+  ros_img.header.frame_id = frame_id;
+  ros_img.height = o3d_img.height_;
+  ros_img.width  = o3d_img.width_;
+  ros_img.step   = o3d_img.BytesPerLine();
+  ros_img.data   = o3d_img.data_;
+  ros_img.is_bigendian = !isLittleEndian();
 }
 
 void rosToOpen3d(
@@ -111,4 +157,19 @@ void rosToOpen3d(
     }
   }
 }
+
+void rosToOpen3d(
+  const sensor_msgs::msg::Image & ros_img,
+  open3d::geometry::Image o3d_img)
+{
+  o3d_img.Prepare(
+    ros_img.width,
+    ros_img.height,
+    sensor_msgs::image_encodings::numChannels(ros_img.encoding),
+    sensor_msgs::image_encodings::bitDepth(ros_img.encoding)/8
+  );
+  assert(o3d_img.data_.size() == ros_img.data.size());
+  std::memcpy(o3d_img.data_.data(), ros_img.data.data(), ros_img.data.size());
+}
+
 }  // namespace open3d_conversions

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -17,17 +17,9 @@
 #include <string>
 #include <sstream>
 
+#include <rcpputils/endian.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include "open3d_conversions/open3d_conversions.hpp"
-
-// This is the best we have prior to C++20 std::endian::native
-static bool isLittleEndian()
-{
-  const int32_t value = 0x01;
-  const std::byte * least_significant_address =
-    reinterpret_cast<const std::byte *>(&value);
-  return *least_significant_address == std::byte{0x01};
-}
 
 // Verify that an encoding makes sense with a given image
 static void checkEncodingValidity(
@@ -114,7 +106,7 @@ void open3dToRos(
   ros_img.width = o3d_img.width_;
   ros_img.step = o3d_img.BytesPerLine();
   ros_img.data = o3d_img.data_;
-  ros_img.is_bigendian = !isLittleEndian();
+  ros_img.is_bigendian = rcpputils::endian::native == rcpputils::endian::big;
 }
 
 void open3dToRos(
@@ -227,7 +219,7 @@ void moveOpen3dToRos(
   ros_img.height = o3d_img.height_;
   ros_img.width = o3d_img.width_;
   ros_img.step = o3d_img.BytesPerLine();
-  ros_img.is_bigendian = !isLittleEndian();
+  ros_img.is_bigendian = rcpputils::endian::native == rcpputils::endian::big;
   ros_img.data = std::move(o3d_img.data_);
 
   // Make sure to leave everything in a well defined state

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -28,6 +28,32 @@ static bool isLittleEndian(){
   return (*least_significant_address == std::byte{0x01});
 }
 
+// Verify that an encoding makes sense with a given image
+static void checkEncodingValidity(
+  const std::string& encoding, 
+  const open3d::geometry::Image & o3d_img)
+{
+  const int expected_num_channels = sensor_msgs::image_encodings::numChannels(encoding);
+  const int expected_bytes_per_channel = sensor_msgs::image_encodings::bitDepth(encoding)/8;
+
+  if (expected_num_channels != o3d_img.num_of_channels_){
+    std::stringstream ss;
+    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
+       << "You asked for \"" << encoding << "\" which has " << expected_num_channels
+       << "channels but the provided image had " << o3d_img.num_of_channels_ << " channels";
+    throw std::runtime_error(ss.str());
+  }
+
+  if (expected_bytes_per_channel != o3d_img.bytes_per_channel_){
+    std::stringstream ss;
+    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
+       << "You asked for \"" << encoding << "\" which has " << expected_bytes_per_channel
+       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_ 
+       << " bytes per channel";
+    throw std::runtime_error(ss.str());
+  }
+}
+
 namespace open3d_conversions
 {
 void open3dToRos(
@@ -80,27 +106,7 @@ void open3dToRos(
   std::string encoding,
   std::string frame_id)
 {
-  const int expected_num_channels = sensor_msgs::image_encodings::numChannels(encoding);
-  const int expected_bytes_per_channel = sensor_msgs::image_encodings::bitDepth(encoding)/8;
-
-  // Verify that the encoding makes sense with the given image
-  if (expected_num_channels != o3d_img.num_of_channels_){
-    std::stringstream ss;
-    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
-       << "You asked for \"" << encoding << "\" which has " << expected_num_channels
-       << "channels but the provided image had " << o3d_img.num_of_channels_ << " channels";
-    throw std::runtime_error(ss.str());
-  }
-
-  if (expected_bytes_per_channel != o3d_img.bytes_per_channel_){
-    std::stringstream ss;
-    ss << "Mismatch between Open3D image encoding and desired embedded encoding"
-       << "You asked for \"" << encoding << "\" which has " << expected_bytes_per_channel
-       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_ 
-       << " bytes per channel";
-    throw std::runtime_error(ss.str());
-  }
-
+  checkEncodingValidity(encoding, o3d_img);
   ros_img.encoding = encoding;
   ros_img.header.frame_id = frame_id;
   ros_img.height = o3d_img.height_;
@@ -108,6 +114,30 @@ void open3dToRos(
   ros_img.step   = o3d_img.BytesPerLine();
   ros_img.data   = o3d_img.data_;
   ros_img.is_bigendian = !isLittleEndian();
+}
+
+void open3dToRos(
+  const open3d::camera::PinholeCameraIntrinsic & intrinsic,
+  sensor_msgs::msg::CameraInfo & camera_info,
+  std::string frame_id)
+{
+  // Intrinsic matrix is 3x3 row-major
+  std::fill(camera_info.k.begin(), camera_info.k.end(), 0.0);
+  std::fill(camera_info.p.begin(), camera_info.p.end(), 0.0);
+  for (std::size_t i = 0; i < 9; i++){
+    camera_info.k[i] = intrinsic.intrinsic_matrix_(i/3, i%3);
+  }
+  // Assuming image from monocular camera
+  for (std::size_t i = 0; i < 12; i++){
+    if (i%4 < 3){
+      camera_info.p[i] = intrinsic.intrinsic_matrix_(i/4, i%4);
+    }
+  }
+
+  // Open3d intrinsics do not contain distortion information
+  camera_info.distortion_model = "plumb_bob";
+  camera_info.d.resize(5);
+  std::fill(camera_info.d.begin(), camera_info.d.end(), 0.0);
 }
 
 void rosToOpen3d(
@@ -160,7 +190,7 @@ void rosToOpen3d(
 
 void rosToOpen3d(
   const sensor_msgs::msg::Image & ros_img,
-  open3d::geometry::Image o3d_img)
+  open3d::geometry::Image & o3d_img)
 {
   o3d_img.Prepare(
     ros_img.width,
@@ -168,8 +198,59 @@ void rosToOpen3d(
     sensor_msgs::image_encodings::numChannels(ros_img.encoding),
     sensor_msgs::image_encodings::bitDepth(ros_img.encoding)/8
   );
-  assert(o3d_img.data_.size() == ros_img.data.size());
-  std::memcpy(o3d_img.data_.data(), ros_img.data.data(), ros_img.data.size());
+  o3d_img.data_ = ros_img.data;
+}
+
+void rosToOpen3d(
+  const sensor_msgs::msg::CameraInfo & camera_info,
+  open3d::camera::PinholeCameraIntrinsic & intrinsic)
+{
+  intrinsic.width_  = camera_info.width;
+  intrinsic.height_ = camera_info.height;
+  for (std::size_t row = 0; row < 3; row++){
+    for (std::size_t col = 0; col < 3; col++){
+      intrinsic.intrinsic_matrix_(row, col) = camera_info.k[3*row + col];
+    }
+  }
+}
+
+void moveOpen3dToRos(
+  open3d::geometry::Image && o3d_img,
+  sensor_msgs::msg::Image & ros_img,
+  std::string encoding,
+  std::string frame_id)
+{
+  checkEncodingValidity(encoding, o3d_img);
+  ros_img.encoding = encoding;
+  ros_img.header.frame_id = frame_id;
+  ros_img.height = o3d_img.height_;
+  ros_img.width  = o3d_img.width_;
+  ros_img.step   = o3d_img.BytesPerLine();
+  ros_img.is_bigendian = !isLittleEndian();
+  ros_img.data   = std::move(o3d_img.data_);
+
+  // Make sure to leave everything in a well defined state
+  o3d_img.Clear();
+}
+
+void moveRosToOpen3d(
+  sensor_msgs::msg::Image && ros_img,
+  open3d::geometry::Image & o3d_img)
+{
+  o3d_img.Prepare(
+    ros_img.width,
+    ros_img.height,
+    sensor_msgs::image_encodings::numChannels(ros_img.encoding),
+    sensor_msgs::image_encodings::bitDepth(ros_img.encoding)/8
+  );
+  o3d_img.data_ = std::move(ros_img.data);
+
+  // Make sure to leave everything in a well defined state
+  ros_img.data.clear();
+  ros_img.step = 0;
+  ros_img.height = 0;
+  ros_img.width = 0;
+  ros_img.encoding.clear();
 }
 
 }  // namespace open3d_conversions

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -21,22 +21,23 @@
 #include "open3d_conversions/open3d_conversions.hpp"
 
 // This is the best we have prior to C++20 std::endian::native
-static bool isLittleEndian(){
+static bool isLittleEndian()
+{
   const int32_t value = 0x01;
-  const std::byte * least_significant_address = 
+  const std::byte * least_significant_address =
     reinterpret_cast<const std::byte *>(&value);
-  return (*least_significant_address == std::byte{0x01});
+  return *least_significant_address == std::byte{0x01};
 }
 
 // Verify that an encoding makes sense with a given image
 static void checkEncodingValidity(
-  const std::string& encoding, 
+  const std::string & encoding,
   const open3d::geometry::Image & o3d_img)
 {
   const int expected_num_channels = sensor_msgs::image_encodings::numChannels(encoding);
-  const int expected_bytes_per_channel = sensor_msgs::image_encodings::bitDepth(encoding)/8;
+  const int expected_bytes_per_channel = sensor_msgs::image_encodings::bitDepth(encoding) / 8;
 
-  if (expected_num_channels != o3d_img.num_of_channels_){
+  if (expected_num_channels != o3d_img.num_of_channels_) {
     std::stringstream ss;
     ss << "Mismatch between Open3D image encoding and desired embedded encoding"
        << "You asked for \"" << encoding << "\" which has " << expected_num_channels
@@ -44,11 +45,11 @@ static void checkEncodingValidity(
     throw std::runtime_error(ss.str());
   }
 
-  if (expected_bytes_per_channel != o3d_img.bytes_per_channel_){
+  if (expected_bytes_per_channel != o3d_img.bytes_per_channel_) {
     std::stringstream ss;
     ss << "Mismatch between Open3D image encoding and desired embedded encoding"
        << "You asked for \"" << encoding << "\" which has " << expected_bytes_per_channel
-       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_ 
+       << "bytes per channel but the provided image had " << o3d_img.bytes_per_channel_
        << " bytes per channel";
     throw std::runtime_error(ss.str());
   }
@@ -110,9 +111,9 @@ void open3dToRos(
   ros_img.encoding = encoding;
   ros_img.header.frame_id = frame_id;
   ros_img.height = o3d_img.height_;
-  ros_img.width  = o3d_img.width_;
-  ros_img.step   = o3d_img.BytesPerLine();
-  ros_img.data   = o3d_img.data_;
+  ros_img.width = o3d_img.width_;
+  ros_img.step = o3d_img.BytesPerLine();
+  ros_img.data = o3d_img.data_;
   ros_img.is_bigendian = !isLittleEndian();
 }
 
@@ -124,13 +125,13 @@ void open3dToRos(
   // Intrinsic matrix is 3x3 row-major
   std::fill(camera_info.k.begin(), camera_info.k.end(), 0.0);
   std::fill(camera_info.p.begin(), camera_info.p.end(), 0.0);
-  for (std::size_t i = 0; i < 9; i++){
-    camera_info.k[i] = intrinsic.intrinsic_matrix_(i/3, i%3);
+  for (std::size_t i = 0; i < 9; i++) {
+    camera_info.k[i] = intrinsic.intrinsic_matrix_(i / 3, i % 3);
   }
   // Assuming image from monocular camera
-  for (std::size_t i = 0; i < 12; i++){
-    if (i%4 < 3){
-      camera_info.p[i] = intrinsic.intrinsic_matrix_(i/4, i%4);
+  for (std::size_t i = 0; i < 12; i++) {
+    if (i % 4 < 3) {
+      camera_info.p[i] = intrinsic.intrinsic_matrix_(i / 4, i % 4);
     }
   }
 
@@ -196,7 +197,7 @@ void rosToOpen3d(
     ros_img.width,
     ros_img.height,
     sensor_msgs::image_encodings::numChannels(ros_img.encoding),
-    sensor_msgs::image_encodings::bitDepth(ros_img.encoding)/8
+    sensor_msgs::image_encodings::bitDepth(ros_img.encoding) / 8
   );
   o3d_img.data_ = ros_img.data;
 }
@@ -205,11 +206,11 @@ void rosToOpen3d(
   const sensor_msgs::msg::CameraInfo & camera_info,
   open3d::camera::PinholeCameraIntrinsic & intrinsic)
 {
-  intrinsic.width_  = camera_info.width;
+  intrinsic.width_ = camera_info.width;
   intrinsic.height_ = camera_info.height;
-  for (std::size_t row = 0; row < 3; row++){
-    for (std::size_t col = 0; col < 3; col++){
-      intrinsic.intrinsic_matrix_(row, col) = camera_info.k[3*row + col];
+  for (std::size_t row = 0; row < 3; row++) {
+    for (std::size_t col = 0; col < 3; col++) {
+      intrinsic.intrinsic_matrix_(row, col) = camera_info.k[3 * row + col];
     }
   }
 }
@@ -224,10 +225,10 @@ void moveOpen3dToRos(
   ros_img.encoding = encoding;
   ros_img.header.frame_id = frame_id;
   ros_img.height = o3d_img.height_;
-  ros_img.width  = o3d_img.width_;
-  ros_img.step   = o3d_img.BytesPerLine();
+  ros_img.width = o3d_img.width_;
+  ros_img.step = o3d_img.BytesPerLine();
   ros_img.is_bigendian = !isLittleEndian();
-  ros_img.data   = std::move(o3d_img.data_);
+  ros_img.data = std::move(o3d_img.data_);
 
   // Make sure to leave everything in a well defined state
   o3d_img.Clear();
@@ -241,7 +242,7 @@ void moveRosToOpen3d(
     ros_img.width,
     ros_img.height,
     sensor_msgs::image_encodings::numChannels(ros_img.encoding),
-    sensor_msgs::image_encodings::bitDepth(ros_img.encoding)/8
+    sensor_msgs::image_encodings::bitDepth(ros_img.encoding) / 8
   );
   o3d_img.data_ = std::move(ros_img.data);
 

--- a/open3d_conversions/test/test_open3d_conversions.cpp
+++ b/open3d_conversions/test/test_open3d_conversions.cpp
@@ -1,11 +1,11 @@
 // Copyright 2020 Autonomous Robots Lab, University of Nevada, Reno
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/open3d_conversions/test/test_open3d_conversions.cpp
+++ b/open3d_conversions/test/test_open3d_conversions.cpp
@@ -37,7 +37,7 @@ TEST(ConversionFunctions, open3dToRos2_uncoloredPointcloud) {
     o3d_pc.points_.push_back(Eigen::Vector3d(0.5 * i, i * i, 10.5 * i));
   }
   sensor_msgs::msg::PointCloud2 ros_pc2;
-  open3d_conversions::open3dToRos(o3d_pc, ros_pc2, "o3d_frame");
+  open3d_conversions::open3dToRos(o3d_pc, ros_pc2);
   EXPECT_EQ(ros_pc2.height * ros_pc2.width, o3d_pc.points_.size());
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_x(ros_pc2, "x");
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_y(ros_pc2, "y");
@@ -57,7 +57,7 @@ TEST(ConversionFunctions, open3dToRos2_coloredPointcloud) {
       Eigen::Vector3d(2 * i / 255.0, 5 * i / 255.0, 10 * i / 255.0));
   }
   sensor_msgs::msg::PointCloud2 ros_pc2;
-  open3d_conversions::open3dToRos(o3d_pc, ros_pc2, "o3d_frame");
+  open3d_conversions::open3dToRos(o3d_pc, ros_pc2);
   EXPECT_EQ(ros_pc2.height * ros_pc2.width, o3d_pc.points_.size());
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_x(ros_pc2, "x");
   sensor_msgs::PointCloud2Iterator<float> ros_pc2_y(ros_pc2, "y");

--- a/open3d_conversions/test/test_open3d_conversions.cpp
+++ b/open3d_conversions/test/test_open3d_conversions.cpp
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ROS
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-
 // GTest
 #include <gtest/gtest.h>
 
@@ -26,12 +22,16 @@
 #include <memory>
 
 // ROS
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <rcpputils/endian.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 // open3d_conversions
 #include "open3d_conversions/open3d_conversions.hpp"
 
-TEST(ConversionFunctions, open3dToRos2_uncolored) {
+TEST(ConversionFunctions, open3dToRos2_uncoloredPointcloud) {
   open3d::geometry::PointCloud o3d_pc;
   for (int i = 0; i < 5; ++i) {
     o3d_pc.points_.push_back(Eigen::Vector3d(0.5 * i, i * i, 10.5 * i));
@@ -49,7 +49,7 @@ TEST(ConversionFunctions, open3dToRos2_uncolored) {
   }
 }
 
-TEST(ConversionFunctions, open3dToRos2_colored) {
+TEST(ConversionFunctions, open3dToRos2_coloredPointcloud) {
   open3d::geometry::PointCloud o3d_pc;
   for (int i = 0; i < 5; ++i) {
     o3d_pc.points_.push_back(Eigen::Vector3d(0.5 * i, i * i, 10.5 * i));
@@ -77,7 +77,7 @@ TEST(ConversionFunctions, open3dToRos2_colored) {
   }
 }
 
-TEST(ConversionFunctions, rosToOpen3d_uncolored) {
+TEST(ConversionFunctions, rosToOpen3d_uncoloredPointcloud) {
   sensor_msgs::msg::PointCloud2 ros_pc2;
   ros_pc2.header.frame_id = "ros";
   ros_pc2.height = 1;
@@ -111,7 +111,7 @@ TEST(ConversionFunctions, rosToOpen3d_uncolored) {
   }
 }
 
-TEST(ConversionFunctions, rosToOpen3d_colored) {
+TEST(ConversionFunctions, rosToOpen3d_coloredPointcloud) {
   sensor_msgs::msg::PointCloud2 ros_pc2;
   ros_pc2.header.frame_id = "ros";
   ros_pc2.height = 1;
@@ -155,6 +155,423 @@ TEST(ConversionFunctions, rosToOpen3d_colored) {
     EXPECT_EQ(color(0), 2 * i / 255.0);
     EXPECT_EQ(color(1), 5 * i / 255.0);
     EXPECT_EQ(color(2), 10 * i / 255.0);
+  }
+}
+
+TEST(ConversionFunctions, open3dToRos2_wellFormattedImage) {
+  open3d::geometry::Image o3d_image;
+  o3d_image.bytes_per_channel_ = 2;
+  o3d_image.height_ = 4;
+  o3d_image.width_ = 5;
+  o3d_image.num_of_channels_ = 3;
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      // R
+      o3d_image.data_.push_back(static_cast<uint8_t>(row));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col));
+      // G
+      o3d_image.data_.push_back(static_cast<uint8_t>(row * 5));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col * 3));
+      // B
+      o3d_image.data_.push_back(static_cast<uint8_t>(row + 2));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  sensor_msgs::msg::Image ros_image;
+  open3d_conversions::open3dToRos(o3d_image, ros_image, "rgb16");
+
+  EXPECT_EQ(
+    o3d_image.bytes_per_channel_,
+    sensor_msgs::image_encodings::bitDepth(ros_image.encoding) / 8
+  );
+  EXPECT_EQ(
+    o3d_image.num_of_channels_,
+    sensor_msgs::image_encodings::numChannels(ros_image.encoding)
+  );
+  EXPECT_EQ(o3d_image.width_, ros_image.width);
+  EXPECT_EQ(o3d_image.height_, ros_image.height);
+  EXPECT_EQ(o3d_image.BytesPerLine(), ros_image.step);
+  EXPECT_EQ(ros_image.is_bigendian, rcpputils::endian::native == rcpputils::endian::big);
+  EXPECT_EQ(ros_image.encoding, "rgb16");
+
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      const std::size_t pixel_start_idx = (row * ros_image.width + col) *
+        o3d_image.num_of_channels_ * o3d_image.bytes_per_channel_;
+
+      const uint8_t R1 = ros_image.data.at(pixel_start_idx + 0);
+      const uint8_t R2 = ros_image.data.at(pixel_start_idx + 1);
+      const uint8_t G1 = ros_image.data.at(pixel_start_idx + 2);
+      const uint8_t G2 = ros_image.data.at(pixel_start_idx + 3);
+      const uint8_t B1 = ros_image.data.at(pixel_start_idx + 4);
+      const uint8_t B2 = ros_image.data.at(pixel_start_idx + 5);
+
+      EXPECT_EQ(R1, static_cast<uint8_t>(row));
+      EXPECT_EQ(R2, static_cast<uint8_t>(col));
+      EXPECT_EQ(G1, static_cast<uint8_t>(row * 5));
+      EXPECT_EQ(G2, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(B1, static_cast<uint8_t>(row + 2));
+      EXPECT_EQ(B2, static_cast<uint8_t>(col + 6));
+    }
+  }
+}
+
+TEST(ConversionFunctions, open3dToRos2_moveWellFormattedImage) {
+  open3d::geometry::Image o3d_image;
+  o3d_image.bytes_per_channel_ = 2;
+  o3d_image.height_ = 4;
+  o3d_image.width_ = 5;
+  o3d_image.num_of_channels_ = 3;
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      // R
+      o3d_image.data_.push_back(static_cast<uint8_t>(row));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col));
+      // G
+      o3d_image.data_.push_back(static_cast<uint8_t>(row * 5));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col * 3));
+      // B
+      o3d_image.data_.push_back(static_cast<uint8_t>(row + 2));
+      o3d_image.data_.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  sensor_msgs::msg::Image ros_image;
+  open3d_conversions::moveOpen3dToRos(std::move(o3d_image), ros_image, "rgb16");
+
+  // Moved-from image should be cleared
+  EXPECT_EQ(o3d_image.width_, 0.0);
+  EXPECT_EQ(o3d_image.width_, 0.0);
+  EXPECT_EQ(o3d_image.bytes_per_channel_, 0);
+  EXPECT_EQ(o3d_image.num_of_channels_, 0);
+  EXPECT_TRUE(o3d_image.data_.empty());
+
+  EXPECT_EQ(sensor_msgs::image_encodings::bitDepth(ros_image.encoding), 16);
+  EXPECT_EQ(sensor_msgs::image_encodings::numChannels(ros_image.encoding), 3);
+  EXPECT_EQ(ros_image.width, 5);
+  EXPECT_EQ(ros_image.height, 4);
+  EXPECT_EQ(ros_image.step, 30);
+  EXPECT_EQ(ros_image.is_bigendian, rcpputils::endian::native == rcpputils::endian::big);
+  EXPECT_EQ(ros_image.encoding, "rgb16");
+
+  const std::size_t pixel_size = ros_image.step / ros_image.width;
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      const std::size_t pixel_start_idx = (row * ros_image.width + col) * pixel_size;
+      const uint8_t R1 = ros_image.data.at(pixel_start_idx + 0);
+      const uint8_t R2 = ros_image.data.at(pixel_start_idx + 1);
+      const uint8_t G1 = ros_image.data.at(pixel_start_idx + 2);
+      const uint8_t G2 = ros_image.data.at(pixel_start_idx + 3);
+      const uint8_t B1 = ros_image.data.at(pixel_start_idx + 4);
+      const uint8_t B2 = ros_image.data.at(pixel_start_idx + 5);
+
+      EXPECT_EQ(R1, static_cast<uint8_t>(row));
+      EXPECT_EQ(R2, static_cast<uint8_t>(col));
+      EXPECT_EQ(G1, static_cast<uint8_t>(row * 5));
+      EXPECT_EQ(G2, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(B1, static_cast<uint8_t>(row + 2));
+      EXPECT_EQ(B2, static_cast<uint8_t>(col + 6));
+    }
+  }
+}
+
+TEST(ConversionFunctions, open3dToRos2_wronglyFormattedImage) {
+  open3d::geometry::Image o3d_image;
+  o3d_image.bytes_per_channel_ = 2;
+  o3d_image.height_ = 4;
+  o3d_image.width_ = 5;
+  o3d_image.num_of_channels_ = 3;
+
+  sensor_msgs::msg::Image ros_image;
+
+  // Wrong number of channels
+  EXPECT_THROW(
+    open3d_conversions::open3dToRos(o3d_image, ros_image, "mono16"),
+    std::runtime_error
+  );
+
+  // Wrong number of bytes per channel
+  EXPECT_THROW(
+    open3d_conversions::open3dToRos(o3d_image, ros_image, "rgb8"),
+    std::runtime_error
+  );
+}
+
+TEST(ConversionFunctions, open3dToRos2_moveWronglyFormattedImage) {
+  open3d::geometry::Image o3d_image;
+  o3d_image.bytes_per_channel_ = 2;
+  o3d_image.height_ = 4;
+  o3d_image.width_ = 5;
+  o3d_image.num_of_channels_ = 3;
+  o3d_image.data_.resize(o3d_image.BytesPerLine() * o3d_image.height_);
+
+  sensor_msgs::msg::Image ros_image;
+
+  // Wrong number of channels
+  EXPECT_THROW(
+    open3d_conversions::moveOpen3dToRos(std::move(o3d_image), ros_image, "mono16"),
+    std::runtime_error
+  );
+
+  // The move should not have affected the image since the operation was not possible
+  EXPECT_NE(o3d_image.data_.size(), 0);
+  EXPECT_EQ(ros_image.data.size(), 0);
+
+  // Wrong number of bytes per channel
+  EXPECT_THROW(
+    open3d_conversions::moveOpen3dToRos(std::move(o3d_image), ros_image, "rgb8"),
+    std::runtime_error
+  );
+
+  EXPECT_NE(o3d_image.data_.size(), 0);
+  EXPECT_EQ(ros_image.data.size(), 0);
+}
+
+TEST(ConversionFunctions, rosToOpen3d_wellFormattedImage) {
+  sensor_msgs::msg::Image ros_image;
+  ros_image.height = 4;
+  ros_image.width = 5;
+  ros_image.encoding = "16UC3";
+  ros_image.is_bigendian = rcpputils::endian::native == rcpputils::endian::big;
+  ros_image.step = ros_image.width * 3 * 2;
+
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      // R
+      ros_image.data.push_back(static_cast<uint8_t>(row));
+      ros_image.data.push_back(static_cast<uint8_t>(col));
+      // G
+      ros_image.data.push_back(static_cast<uint8_t>(row * 5));
+      ros_image.data.push_back(static_cast<uint8_t>(col * 3));
+      // B
+      ros_image.data.push_back(static_cast<uint8_t>(row + 2));
+      ros_image.data.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  open3d::geometry::Image o3d_image;
+  open3d_conversions::rosToOpen3d(ros_image, o3d_image);
+
+  EXPECT_EQ(
+    o3d_image.bytes_per_channel_,
+    sensor_msgs::image_encodings::bitDepth(ros_image.encoding) / 8
+  );
+  EXPECT_EQ(
+    o3d_image.num_of_channels_,
+    sensor_msgs::image_encodings::numChannels(ros_image.encoding)
+  );
+  EXPECT_EQ(o3d_image.width_, ros_image.width);
+  EXPECT_EQ(o3d_image.height_, ros_image.height);
+  EXPECT_EQ(o3d_image.BytesPerLine(), ros_image.step);
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      const std::size_t pixel_start_idx = (row * o3d_image.width_ + col) *
+        o3d_image.num_of_channels_ * o3d_image.bytes_per_channel_;
+
+      const uint8_t R1 = o3d_image.data_.at(pixel_start_idx + 0);
+      const uint8_t R2 = o3d_image.data_.at(pixel_start_idx + 1);
+      const uint8_t G1 = o3d_image.data_.at(pixel_start_idx + 2);
+      const uint8_t G2 = o3d_image.data_.at(pixel_start_idx + 3);
+      const uint8_t B1 = o3d_image.data_.at(pixel_start_idx + 4);
+      const uint8_t B2 = o3d_image.data_.at(pixel_start_idx + 5);
+
+      EXPECT_EQ(R1, static_cast<uint8_t>(row));
+      EXPECT_EQ(R2, static_cast<uint8_t>(col));
+      EXPECT_EQ(G1, static_cast<uint8_t>(row * 5));
+      EXPECT_EQ(G2, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(B1, static_cast<uint8_t>(row + 2));
+      EXPECT_EQ(B2, static_cast<uint8_t>(col + 6));
+    }
+  }
+}
+
+TEST(ConversionFunctions, rosToOpen3d_moveWellFormattedImage) {
+  sensor_msgs::msg::Image ros_image;
+  ros_image.height = 4;
+  ros_image.width = 5;
+  ros_image.encoding = "16UC3";
+  ros_image.is_bigendian = rcpputils::endian::native == rcpputils::endian::big;
+  ros_image.step = ros_image.width * 3 * 2;
+
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      // R
+      ros_image.data.push_back(static_cast<uint8_t>(row));
+      ros_image.data.push_back(static_cast<uint8_t>(col));
+      // G
+      ros_image.data.push_back(static_cast<uint8_t>(row * 5));
+      ros_image.data.push_back(static_cast<uint8_t>(col * 3));
+      // B
+      ros_image.data.push_back(static_cast<uint8_t>(row + 2));
+      ros_image.data.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  open3d::geometry::Image o3d_image;
+  open3d_conversions::moveRosToOpen3d(std::move(ros_image), o3d_image);
+
+  // Moved-from image should be cleared
+  EXPECT_EQ(ros_image.width, 0);
+  EXPECT_EQ(ros_image.height, 0);
+  EXPECT_EQ(ros_image.step, 0);
+  EXPECT_TRUE(ros_image.data.empty());
+  EXPECT_TRUE(ros_image.encoding.empty());
+
+  EXPECT_EQ(o3d_image.bytes_per_channel_, 2);
+  EXPECT_EQ(o3d_image.num_of_channels_, 3);
+  EXPECT_EQ(o3d_image.width_, 5);
+  EXPECT_EQ(o3d_image.height_, 4);
+  EXPECT_EQ(o3d_image.BytesPerLine(), 30);
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      const std::size_t pixel_start_idx = (row * o3d_image.width_ + col) *
+        o3d_image.num_of_channels_ * o3d_image.bytes_per_channel_;
+
+      const uint8_t R1 = o3d_image.data_.at(pixel_start_idx + 0);
+      const uint8_t R2 = o3d_image.data_.at(pixel_start_idx + 1);
+      const uint8_t G1 = o3d_image.data_.at(pixel_start_idx + 2);
+      const uint8_t G2 = o3d_image.data_.at(pixel_start_idx + 3);
+      const uint8_t B1 = o3d_image.data_.at(pixel_start_idx + 4);
+      const uint8_t B2 = o3d_image.data_.at(pixel_start_idx + 5);
+
+      EXPECT_EQ(R1, static_cast<uint8_t>(row));
+      EXPECT_EQ(R2, static_cast<uint8_t>(col));
+      EXPECT_EQ(G1, static_cast<uint8_t>(row * 5));
+      EXPECT_EQ(G2, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(B1, static_cast<uint8_t>(row + 2));
+      EXPECT_EQ(B2, static_cast<uint8_t>(col + 6));
+    }
+  }
+}
+
+TEST(ConversionFunctions, rosToOpen3d_differentEndianness) {
+  sensor_msgs::msg::Image ros_image;
+  ros_image.height = 4;
+  ros_image.width = 5;
+  ros_image.encoding = "bgr16";
+  ros_image.is_bigendian = rcpputils::endian::native != rcpputils::endian::big;
+  ros_image.step = ros_image.width * 3 * 2;
+
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      // R
+      ros_image.data.push_back(static_cast<uint8_t>(row));
+      ros_image.data.push_back(static_cast<uint8_t>(col));
+      // G
+      ros_image.data.push_back(static_cast<uint8_t>(row * 5));
+      ros_image.data.push_back(static_cast<uint8_t>(col * 3));
+      // B
+      ros_image.data.push_back(static_cast<uint8_t>(row + 2));
+      ros_image.data.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  open3d::geometry::Image o3d_image;
+  open3d_conversions::rosToOpen3d(ros_image, o3d_image);
+
+  EXPECT_EQ(
+    o3d_image.bytes_per_channel_,
+    sensor_msgs::image_encodings::bitDepth(ros_image.encoding) / 8
+  );
+  EXPECT_EQ(
+    o3d_image.num_of_channels_,
+    sensor_msgs::image_encodings::numChannels(ros_image.encoding)
+  );
+  EXPECT_EQ(o3d_image.width_, ros_image.width);
+  EXPECT_EQ(o3d_image.height_, ros_image.height);
+  EXPECT_EQ(o3d_image.BytesPerLine(), ros_image.step);
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      const std::size_t pixel_start_idx = (row * o3d_image.width_ + col) *
+        o3d_image.num_of_channels_ * o3d_image.bytes_per_channel_;
+
+      const uint8_t R1 = o3d_image.data_.at(pixel_start_idx + 0);
+      const uint8_t R2 = o3d_image.data_.at(pixel_start_idx + 1);
+      const uint8_t G1 = o3d_image.data_.at(pixel_start_idx + 2);
+      const uint8_t G2 = o3d_image.data_.at(pixel_start_idx + 3);
+      const uint8_t B1 = o3d_image.data_.at(pixel_start_idx + 4);
+      const uint8_t B2 = o3d_image.data_.at(pixel_start_idx + 5);
+
+      // Note that these are flipped relative to how they were initialized
+      EXPECT_EQ(R1, static_cast<uint8_t>(col));
+      EXPECT_EQ(R2, static_cast<uint8_t>(row));
+      EXPECT_EQ(G1, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(G2, static_cast<uint8_t>(row * 5));
+      EXPECT_EQ(B1, static_cast<uint8_t>(col + 6));
+      EXPECT_EQ(B2, static_cast<uint8_t>(row + 2));
+    }
+  }
+}
+
+TEST(ConversionFunctions, rosToOpen3d_moveWithDifferentEndianness) {
+  sensor_msgs::msg::Image ros_image;
+  ros_image.height = 4;
+  ros_image.width = 5;
+  ros_image.encoding = "32SC2";
+  ros_image.is_bigendian = rcpputils::endian::native != rcpputils::endian::big;
+  ros_image.step = ros_image.width * 4 * 2;
+
+  for (std::size_t row = 0; row < ros_image.height; ++row) {
+    for (std::size_t col = 0; col < ros_image.width; ++col) {
+      // Ch. 1
+      ros_image.data.push_back(static_cast<uint8_t>(row));
+      ros_image.data.push_back(static_cast<uint8_t>(col));
+      ros_image.data.push_back(static_cast<uint8_t>(row + col));
+      ros_image.data.push_back(static_cast<uint8_t>(row * col));
+      // Ch. 2
+      ros_image.data.push_back(static_cast<uint8_t>(row * 5));
+      ros_image.data.push_back(static_cast<uint8_t>(col * 3));
+      ros_image.data.push_back(static_cast<uint8_t>(row + 2));
+      ros_image.data.push_back(static_cast<uint8_t>(col + 6));
+    }
+  }
+
+  open3d::geometry::Image o3d_image;
+  open3d_conversions::moveRosToOpen3d(std::move(ros_image), o3d_image);
+
+  // Can compare against original image because a move was not possible
+  EXPECT_EQ(
+    o3d_image.bytes_per_channel_,
+    sensor_msgs::image_encodings::bitDepth(ros_image.encoding) / 8
+  );
+  EXPECT_EQ(
+    o3d_image.num_of_channels_,
+    sensor_msgs::image_encodings::numChannels(ros_image.encoding)
+  );
+  EXPECT_EQ(o3d_image.width_, ros_image.width);
+  EXPECT_EQ(o3d_image.height_, ros_image.height);
+  EXPECT_EQ(o3d_image.BytesPerLine(), ros_image.step);
+
+  for (std::size_t row = 0; row < o3d_image.height_; ++row) {
+    for (std::size_t col = 0; col < o3d_image.width_; ++col) {
+      const std::size_t pixel_start_idx = (row * o3d_image.width_ + col) *
+        o3d_image.num_of_channels_ * o3d_image.bytes_per_channel_;
+
+      const uint8_t Ch1_1 = o3d_image.data_.at(pixel_start_idx + 0);
+      const uint8_t Ch1_2 = o3d_image.data_.at(pixel_start_idx + 1);
+      const uint8_t Ch1_3 = o3d_image.data_.at(pixel_start_idx + 2);
+      const uint8_t Ch1_4 = o3d_image.data_.at(pixel_start_idx + 3);
+      const uint8_t Ch2_1 = o3d_image.data_.at(pixel_start_idx + 4);
+      const uint8_t Ch2_2 = o3d_image.data_.at(pixel_start_idx + 5);
+      const uint8_t Ch2_3 = o3d_image.data_.at(pixel_start_idx + 6);
+      const uint8_t Ch2_4 = o3d_image.data_.at(pixel_start_idx + 7);
+
+      // Note that these are flipped relative to how they were initialized
+      EXPECT_EQ(Ch1_1, static_cast<uint8_t>(row * col));
+      EXPECT_EQ(Ch1_2, static_cast<uint8_t>(row + col));
+      EXPECT_EQ(Ch1_3, static_cast<uint8_t>(col));
+      EXPECT_EQ(Ch1_4, static_cast<uint8_t>(row));
+      EXPECT_EQ(Ch2_1, static_cast<uint8_t>(col + 6));
+      EXPECT_EQ(Ch2_2, static_cast<uint8_t>(row + 2));
+      EXPECT_EQ(Ch2_3, static_cast<uint8_t>(col * 3));
+      EXPECT_EQ(Ch2_4, static_cast<uint8_t>(row * 5));
+    }
   }
 }
 


### PR DESCRIPTION
I'm currently working on a project using Open3D's TSDF integration pipeline and had a need to convert between ROS and Open3D image formats. I figured it might be worth submitting my conversion code here. This PR adds support for :
- `open3d::geometry::Image` -> `sensor_msgs::msg::Image`
- `open3d::camera::PinholeCameraIntrinsic` -> `sensor_msgs::msg::CameraInfo`
- `sensor_msgs::msg::Image` -> `open3d::geometry::Image`
- `sensor_msgs::msg::CameraInfo` -> `open3d::camera::PinholeCameraIntrinsic`

Additionally, since the data layout is the same in both formats, it provides move-only versions of 
- `open3d::geometry::Image` -> `sensor_msgs::msg::Image`
- `sensor_msgs::msg::Image` -> `open3d::geometry::Image`

I've run some qualitative tests using visualization in RViz and the Open3D visualizer to verify that images appear the same passing from ROS to Open3D and then back to ROS. I've performed similar tests for the CameraInfo functions. The formats I had available to me for testing were `rgb8` (RGB image), `16UC1` (depth image), and `mono8` (grayscale image)