### PR TITLE
bump cmake minimum required to match noetic rep

### DIFF
--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.16.3)
 project(open3d_conversions)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
CMake minimum version is 3.16.3 on noetic, which is the only active ros 1 distro left.
This bump is required due to a CMake error when trying to specify the Open3d install directory through the `Open3D_ROOT` env var.

```sh
Errors     << open3d_conversions:cmake /aces_2_repos/logs/open3d_conversions/build.cmake.016.log                                                                                                                                                                                     
CMake Warning (dev) at CMakeLists.txt:12 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable Open3D_ROOT is set to:

    /aces_2_repos/src/open3d

  Environment variable Open3D_ROOT is set to:

    /aces_2_repos/src/open3d/

  For compatibility, CMake is ignoring the variable.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /aces_2_repos/src/perception_open3d/open3d_conversions/CMakeLists.txt:12 (find_package):
  By not providing "FindOpen3D.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Open3D", but
  CMake did not find one.

  Could not find a package configuration file provided by "Open3D" with any
  of the following names:

    Open3DConfig.cmake
    open3d-config.cmake

  Add the installation prefix of "Open3D" to CMAKE_PREFIX_PATH or set
  "Open3D_DIR" to a directory containing one of the above files.  If "Open3D"
  provides a separate development package or SDK, be sure it has been
  installed.
```