### PR TITLE
Add support for pointcloud normals

### DIFF
--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -8,31 +8,24 @@ endif()
 
 # system dependencies
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_ros REQUIRED)
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(Open3D REQUIRED)
 
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIR}
-  ${Open3D_INCLUDE_DIRS}
-)
-
 add_library(open3d_conversions src/open3d_conversions.cpp)
 target_include_directories(open3d_conversions PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(
-  open3d_conversions
-  "rclcpp"
-  "rcpputils"
-  "sensor_msgs"
+target_link_libraries(open3d_conversions
+  rclcpp::rclcpp
+  rcpputils::rcpputils
+  ${sensor_msgs_TARGETS}
+  Eigen3::Eigen
+  Open3D::Open3D
 )
-target_link_libraries(open3d_conversions ${Open3D_LIBRARIES})
 target_compile_definitions(open3d_conversions PUBLIC "OPEN3D_CONVERSIONS_BUILDING_LIBRARY")
 
 install(
@@ -59,6 +52,6 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(open3d_conversions)
 ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(Open3D rclcpp)
+ament_export_dependencies(Eigen3 Open3D rclcpp rcpputils sensor_msgs)
 
 ament_package()

--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -5,6 +5,7 @@ project(open3d_conversions)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # system dependencies
 find_package(ament_cmake REQUIRED)

--- a/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
+++ b/open3d_conversions/include/open3d_conversions/open3d_conversions.hpp
@@ -18,7 +18,9 @@
 #include <Eigen/Dense>
 
 // Open3D
-#include <open3d/Open3D.h>
+#include <open3d/geometry/Image.h>
+#include <open3d/geometry/PointCloud.h>
+#include <open3d/camera/PinholeCameraIntrinsic.h>
 
 // C++
 #include <string>

--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -13,7 +13,8 @@
 
   <author email="matnay17@gmail.com">Pranay Mathur</author>
   <author email="nkhedekar@nevada.unr.edu">Nikhil Khedekar</author>
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>libopen3d-dev</depend>
   <depend>rclcpp</depend>

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -167,46 +167,51 @@ void rosToOpen3d(
   const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2,
   open3d::geometry::PointCloud & o3d_pc, bool skip_colors)
 {
+  const std::size_t num_points = ros_pc2->height * ros_pc2->width;
+
+  // Standard XYZ coordinate
   sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_x(*ros_pc2, "x");
   sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_y(*ros_pc2, "y");
   sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_z(*ros_pc2, "z");
-  o3d_pc.points_.reserve(ros_pc2->height * ros_pc2->width);
-  if (ros_pc2->fields.size() == 3 || skip_colors == true) {
-    for (size_t i = 0; i < ros_pc2->height * ros_pc2->width;
-      ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z)
-    {
-      o3d_pc.points_.push_back(
-        Eigen::Vector3d(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z));
-    }
-  } else {
-    o3d_pc.colors_.reserve(ros_pc2->height * ros_pc2->width);
-    if (ros_pc2->fields[3].name == "rgb") {
-      sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_r(*ros_pc2, "r");
-      sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_g(*ros_pc2, "g");
-      sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_b(*ros_pc2, "b");
+  o3d_pc.points_.reserve(num_points);
+  for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z) {
+    o3d_pc.points_.push_back(Eigen::Vector3d(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z));
+  }
 
-      for (size_t i = 0; i < ros_pc2->height * ros_pc2->width; ++i, ++ros_pc2_x,
-        ++ros_pc2_y, ++ros_pc2_z, ++ros_pc2_r, ++ros_pc2_g, ++ros_pc2_b)
-      {
-        o3d_pc.points_.push_back(
-          Eigen::Vector3d(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z));
-        o3d_pc.colors_.push_back(
-          Eigen::Vector3d(
+  auto hasField = [&ros_pc2](const std::string& name) {
+    return std::any_of(ros_pc2->fields.begin(), ros_pc2->fields.end(), [&name](const sensor_msgs::msg::PointField& field){return field.name == name;});
+  };
+
+  // Add normals if the input cloud has normals
+  if (hasField("normal_x") && hasField("normal_y") && hasField("normal_z")) {
+    sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_nx(*ros_pc2, "normal_x");
+    sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_ny(*ros_pc2, "normal_y");
+    sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_nz(*ros_pc2, "normal_z");
+    o3d_pc.normals_.reserve(num_points);
+    for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_nx, ++ros_pc2_ny, ++ros_pc2_nz) {
+      o3d_pc.normals_.push_back(Eigen::Vector3d(*ros_pc2_nx, *ros_pc2_ny, *ros_pc2_nz));
+    }
+  }
+
+  // Add colors if the input cloud has colors
+  if (hasField("rgb") || hasField("rgba")) {
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_r(*ros_pc2, "r");
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_g(*ros_pc2, "g");
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_b(*ros_pc2, "b");
+    o3d_pc.colors_.reserve(num_points);
+    for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_r, ++ros_pc2_g, ++ros_pc2_b) {
+      o3d_pc.colors_.push_back(Eigen::Vector3d(
             (static_cast<int>(*ros_pc2_r)) / 255.0,
             (static_cast<int>(*ros_pc2_g)) / 255.0,
             (static_cast<int>(*ros_pc2_b)) / 255.0));
-      }
-    } else if (ros_pc2->fields[3].name == "intensity") {
-      sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_i(*ros_pc2,
-        "intensity");
-      for (size_t i = 0; i < ros_pc2->height * ros_pc2->width;
-        ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z, ++ros_pc2_i)
-      {
-        o3d_pc.points_.push_back(
-          Eigen::Vector3d(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z));
-        o3d_pc.colors_.push_back(
-          Eigen::Vector3d(*ros_pc2_i, *ros_pc2_i, *ros_pc2_i));
-      }
+    }
+  }   
+  // Add intensity as a color if the input cloud has intesity
+  else if (hasField("intensity")) {
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_i(*ros_pc2, "intensity");
+    o3d_pc.colors_.reserve(num_points);
+    for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_i) {
+      o3d_pc.colors_.push_back(Eigen::Vector3d(*ros_pc2_i, *ros_pc2_i, *ros_pc2_i));
     }
   }
 }

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -53,43 +53,38 @@ void open3dToRos(
   const open3d::geometry::PointCloud & pointcloud,
   sensor_msgs::msg::PointCloud2 & ros_pc2)
 {
-  sensor_msgs::PointCloud2Modifier modifier(ros_pc2);
-  modifier.clear();
-  modifier.setPointCloud2FieldsByString(1, "xyz");
+  // Clear the input pointcloud to prepare it to be set
+  std_msgs::msg::Header pc_header = ros_pc2.header;
+  ros_pc2 = sensor_msgs::msg::PointCloud2{};
+  ros_pc2.header = pc_header;
 
-  ros_pc2.point_step = 12;
-  if (pointcloud.HasColors()) {
-    sensor_msgs::msg::PointField & rgb_field = ros_pc2.fields.emplace_back();
-    rgb_field.count = 1;
-    rgb_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
-    rgb_field.name = "rgb";
-    rgb_field.offset = ros_pc2.point_step;
+  // We define a lambda for new fields to avoid code repetition
+  // This only works because all our fields have the same structure
+  auto add_new_field = [&ros_pc2](const std::string& field_name) {
+    sensor_msgs::msg::PointField & new_field = ros_pc2.fields.emplace_back();
+    new_field.count = 1;
+    new_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
+    new_field.name = field_name;
+    new_field.offset = ros_pc2.point_step;
     ros_pc2.point_step += 4;
+  };  
+
+  add_new_field("x");
+  add_new_field("y");
+  add_new_field("z");
+
+  if (pointcloud.HasColors()) {
+    // Note that the RGB field is typically packed as a single FLOAT32 value
+    add_new_field("rgb");
   }
 
   if (pointcloud.HasNormals()) {
-    sensor_msgs::msg::PointField & nx_field = ros_pc2.fields.emplace_back();
-    nx_field.count = 1;
-    nx_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
-    nx_field.name = "normal_x";
-    nx_field.offset = ros_pc2.point_step;
-    ros_pc2.point_step += 4;
-
-    sensor_msgs::msg::PointField & ny_field = ros_pc2.fields.emplace_back();
-    ny_field.count = 1;
-    ny_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
-    ny_field.name = "normal_y";
-    ny_field.offset = ros_pc2.point_step;
-    ros_pc2.point_step += 4;
-
-    sensor_msgs::msg::PointField & nz_field = ros_pc2.fields.emplace_back();
-    nz_field.count = 1;
-    nz_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
-    nz_field.name = "normal_z";
-    nz_field.offset = ros_pc2.point_step;
-    ros_pc2.point_step += 4;
+    add_new_field("normal_x");
+    add_new_field("normal_y");
+    add_new_field("normal_z");
   }
 
+  // Set the parameters known from the open3d pointcloud definition
   ros_pc2.height = 1;
   ros_pc2.width = pointcloud.points_.size();
   ros_pc2.row_step = ros_pc2.width * ros_pc2.point_step;
@@ -97,12 +92,19 @@ void open3dToRos(
   ros_pc2.is_dense = true;
   ros_pc2.data.resize(ros_pc2.row_step);
 
-  float * ros_it = reinterpret_cast<float *>(ros_pc2.data.data());  // Technically UB
+  // For clarity we set up this lambda to cleanly set the value and advance the pointer
+  auto * ros_it = ros_pc2.data.data();
+  auto set_next_value = [&ros_it](const auto& value) {
+    std::memcpy(ros_it, &value, sizeof(value));
+    std::advance(ros_it, sizeof(value));
+  };
+
   for (std::size_t idx = 0; idx < pointcloud.points_.size(); ++idx) {
-    const Eigen::Vector3d & point_xyz = pointcloud.points_[idx];
-    *ros_it++ = static_cast<float>(point_xyz.x());
-    *ros_it++ = static_cast<float>(point_xyz.y());
-    *ros_it++ = static_cast<float>(point_xyz.z());
+    const Eigen::Vector3f point_xyz = pointcloud.points_[idx].cast<float>();
+    if (point_xyz.hasNaN()) ros_pc2.is_dense = false;
+    set_next_value(point_xyz.x());
+    set_next_value(point_xyz.y());
+    set_next_value(point_xyz.z());
 
     if (pointcloud.HasColors()) {
       const Eigen::Vector3d & point_rgb = pointcloud.colors_[idx];
@@ -110,14 +112,14 @@ void open3dToRos(
       const uint8_t g = static_cast<uint8_t>(255 * point_rgb(1));
       const uint8_t b = static_cast<uint8_t>(255 * point_rgb(2));
       const uint32_t rgb = (rcpputils::endian::native == rcpputils::endian::big) ? (b << 24 | g << 16 | r << 8) : (r << 16 | g << 8 | b);
-      std::memcpy(ros_it++, &rgb, sizeof(float));
+      set_next_value(rgb);
     }
 
     if (pointcloud.HasNormals()) {
-      const Eigen::Vector3d & point_normal = pointcloud.normals_[idx];
-      *ros_it++ = static_cast<float>(point_normal.x());
-      *ros_it++ = static_cast<float>(point_normal.y());
-      *ros_it++ = static_cast<float>(point_normal.z());
+      const Eigen::Vector3f point_normal = pointcloud.normals_[idx].cast<float>();
+      set_next_value(point_normal.x());
+      set_next_value(point_normal.y());
+      set_next_value(point_normal.z());
     }
   }
 }

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -60,14 +60,14 @@ void open3dToRos(
 
   // We define a lambda for new fields to avoid code repetition
   // This only works because all our fields have the same structure
-  auto add_new_field = [&ros_pc2](const std::string& field_name) {
-    sensor_msgs::msg::PointField & new_field = ros_pc2.fields.emplace_back();
-    new_field.count = 1;
-    new_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
-    new_field.name = field_name;
-    new_field.offset = ros_pc2.point_step;
-    ros_pc2.point_step += 4;
-  };  
+  auto add_new_field = [&ros_pc2](const std::string & field_name) {
+      sensor_msgs::msg::PointField & new_field = ros_pc2.fields.emplace_back();
+      new_field.count = 1;
+      new_field.datatype = sensor_msgs::msg::PointField::FLOAT32;
+      new_field.name = field_name;
+      new_field.offset = ros_pc2.point_step;
+      ros_pc2.point_step += 4;
+    };
 
   add_new_field("x");
   add_new_field("y");
@@ -94,14 +94,14 @@ void open3dToRos(
 
   // For clarity we set up this lambda to cleanly set the value and advance the pointer
   auto * ros_it = ros_pc2.data.data();
-  auto set_next_value = [&ros_it](const auto& value) {
-    std::memcpy(ros_it, &value, sizeof(value));
-    std::advance(ros_it, sizeof(value));
-  };
+  auto set_next_value = [&ros_it](const auto & value) {
+      std::memcpy(ros_it, &value, sizeof(value));
+      std::advance(ros_it, sizeof(value));
+    };
 
   for (std::size_t idx = 0; idx < pointcloud.points_.size(); ++idx) {
     const Eigen::Vector3f point_xyz = pointcloud.points_[idx].cast<float>();
-    if (point_xyz.hasNaN()) ros_pc2.is_dense = false;
+    if (point_xyz.hasNaN()) {ros_pc2.is_dense = false;}
     set_next_value(point_xyz.x());
     set_next_value(point_xyz.y());
     set_next_value(point_xyz.z());
@@ -111,7 +111,9 @@ void open3dToRos(
       const uint8_t r = static_cast<uint8_t>(255 * point_rgb(0));
       const uint8_t g = static_cast<uint8_t>(255 * point_rgb(1));
       const uint8_t b = static_cast<uint8_t>(255 * point_rgb(2));
-      const uint32_t rgb = (rcpputils::endian::native == rcpputils::endian::big) ? (b << 24 | g << 16 | r << 8) : (r << 16 | g << 8 | b);
+      const uint32_t rgb = (rcpputils::endian::native == rcpputils::endian::big) ?
+        (b << 24 | g << 16 | r << 8) :
+        (r << 16 | g << 8 | b);
       set_next_value(rgb);
     }
 

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -178,9 +178,13 @@ void rosToOpen3d(
     o3d_pc.points_.push_back(Eigen::Vector3d(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z));
   }
 
-  auto hasField = [&ros_pc2](const std::string& name) {
-    return std::any_of(ros_pc2->fields.begin(), ros_pc2->fields.end(), [&name](const sensor_msgs::msg::PointField& field){return field.name == name;});
-  };
+  auto hasField = [&ros_pc2](const std::string & name) {
+      return std::any_of(
+        ros_pc2->fields.begin(),
+        ros_pc2->fields.end(),
+        [&name](const sensor_msgs::msg::PointField & field) {return field.name == name;}
+      );
+    };
 
   // Add normals if the input cloud has normals
   if (hasField("normal_x") && hasField("normal_y") && hasField("normal_z")) {
@@ -200,14 +204,14 @@ void rosToOpen3d(
     sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_b(*ros_pc2, "b");
     o3d_pc.colors_.reserve(num_points);
     for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_r, ++ros_pc2_g, ++ros_pc2_b) {
-      o3d_pc.colors_.push_back(Eigen::Vector3d(
-            (static_cast<int>(*ros_pc2_r)) / 255.0,
-            (static_cast<int>(*ros_pc2_g)) / 255.0,
-            (static_cast<int>(*ros_pc2_b)) / 255.0));
+      o3d_pc.colors_.push_back(
+        Eigen::Vector3d(
+          (static_cast<int>(*ros_pc2_r)) / 255.0,
+          (static_cast<int>(*ros_pc2_g)) / 255.0,
+          (static_cast<int>(*ros_pc2_b)) / 255.0));
     }
-  }   
-  // Add intensity as a color if the input cloud has intesity
-  else if (hasField("intensity")) {
+  } else if (hasField("intensity")) {
+    // Add intensity as a color if the input cloud has intesity
     sensor_msgs::PointCloud2ConstIterator<uint8_t> ros_pc2_i(*ros_pc2, "intensity");
     o3d_pc.colors_.reserve(num_points);
     for (std::size_t i = 0; i < num_points; ++i, ++ros_pc2_i) {

--- a/open3d_conversions/test/test_open3d_conversions.cpp
+++ b/open3d_conversions/test/test_open3d_conversions.cpp
@@ -49,6 +49,33 @@ TEST(ConversionFunctions, open3dToRos2_uncoloredPointcloud) {
   }
 }
 
+TEST(ConversionFunction, open3dToRos2_pointcloudWithNormals) {
+  open3d::geometry::PointCloud o3d_pc;
+  for (int i = 0; i < 5; ++i) {
+    o3d_pc.points_.push_back(Eigen::Vector3d(0.5 * i, i * i, 10.5 * i));
+    o3d_pc.normals_.push_back(Eigen::Vector3d(1 + i, i * i, 2 * i).normalized());
+  }
+  sensor_msgs::msg::PointCloud2 ros_pc2;
+  open3d_conversions::open3dToRos(o3d_pc, ros_pc2);
+  EXPECT_EQ(ros_pc2.height * ros_pc2.width, o3d_pc.points_.size());
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_x(ros_pc2, "x");
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_y(ros_pc2, "y");
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_z(ros_pc2, "z");
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_nx(ros_pc2, "normal_x");
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_ny(ros_pc2, "normal_y");
+  sensor_msgs::PointCloud2Iterator<float> ros_pc2_nz(ros_pc2, "normal_z");
+  for (int i = 0; i < 5;
+    i++, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z, ++ros_pc2_nx, ++ros_pc2_ny, ++ros_pc2_nz)
+  {
+    EXPECT_EQ(*ros_pc2_x, 0.5 * i);
+    EXPECT_EQ(*ros_pc2_y, i * i);
+    EXPECT_EQ(*ros_pc2_z, 10.5 * i);
+    EXPECT_EQ(*ros_pc2_nx, o3d_pc.normals_.at(i).x());
+    EXPECT_EQ(*ros_pc2_ny, o3d_pc.normals_.at(i).y());
+    EXPECT_EQ(*ros_pc2_nz, o3d_pc.normals_.at(i).z());
+  }
+}
+
 TEST(ConversionFunctions, open3dToRos2_coloredPointcloud) {
   open3d::geometry::PointCloud o3d_pc;
   for (int i = 0; i < 5; ++i) {
@@ -74,6 +101,56 @@ TEST(ConversionFunctions, open3dToRos2_coloredPointcloud) {
     EXPECT_EQ(*ros_pc2_r, 2 * i);
     EXPECT_EQ(*ros_pc2_g, 5 * i);
     EXPECT_EQ(*ros_pc2_b, 10 * i);
+  }
+}
+
+TEST(ConversionFunctions, rosToOpen3d_pointcloudWithNormals) {
+  sensor_msgs::msg::PointCloud2 ros_pc2;
+  ros_pc2.header.frame_id = "ros";
+  ros_pc2.height = 1;
+  ros_pc2.width = 5;
+  ros_pc2.is_bigendian = false;
+  ros_pc2.is_dense = true;
+  sensor_msgs::PointCloud2Modifier modifier(ros_pc2);
+  modifier.setPointCloud2FieldsByString(1, "xyz");
+  modifier.resize(5 * 1);
+  sensor_msgs::PointCloud2Iterator<float> mod_x(ros_pc2, "x");
+  sensor_msgs::PointCloud2Iterator<float> mod_y(ros_pc2, "y");
+  sensor_msgs::PointCloud2Iterator<float> mod_z(ros_pc2, "z");
+  sensor_msgs::PointCloud2Iterator<float> mod_nx(ros_pc2, "normal_x");
+  sensor_msgs::PointCloud2Iterator<float> mod_ny(ros_pc2, "normal_y");
+  sensor_msgs::PointCloud2Iterator<float> mod_nz(ros_pc2, "normal_z");
+
+  std::vector<Eigen::Vector3d> normals;
+  for (int i = 0; i < 5; ++i, ++mod_x, ++mod_y, ++mod_z) {
+    const Eigen::Vector3d & normal = normals.emplace_back(
+      Eigen::Vector3d(
+        1 + i, i * i,
+        2 * i).normalized());
+    *mod_x = 0.5 * i;
+    *mod_y = i * i;
+    *mod_z = 10.5 * i;
+    *mod_nx = normal.x();
+    *mod_ny = normal.y();
+    *mod_nz = normal.z();
+  }
+
+  const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2_ptr =
+    std::make_shared<sensor_msgs::msg::PointCloud2>(ros_pc2);
+  open3d::geometry::PointCloud o3d_pc;
+  open3d_conversions::rosToOpen3d(ros_pc2_ptr, o3d_pc);
+  EXPECT_EQ(ros_pc2_ptr->height * ros_pc2_ptr->width, o3d_pc.points_.size());
+  EXPECT_EQ(o3d_pc.HasColors(), false);
+  for (unsigned int i = 0; i < 5; i++) {
+    const Eigen::Vector3d & point = o3d_pc.points_.at(i);
+    EXPECT_EQ(point(0), 0.5 * i);
+    EXPECT_EQ(point(1), i * i);
+    EXPECT_EQ(point(2), 10.5 * i);
+
+    const Eigen::Vector3d & normal = o3d_pc.normals_.at(i);
+    EXPECT_EQ(normal(0), normals.at(i).x());
+    EXPECT_EQ(normal(1), normals.at(i).y());
+    EXPECT_EQ(normal(2), normals.at(i).z());
   }
 }
 


### PR DESCRIPTION
Previously, open3d_conversions only migrated point fields that are supported by `sensor_msgs::PointCloud2Modifier::setPointCloud2FieldsByString`, which does not include point normals. Open3D pointclouds support position, color, normals, and covariances. This PR moves away from using `sensor_msgs::PointCloud2Modified`, which has awkward syntax (eg. fields cannot be added incrementally and must all be added in one monolithic step), and adds support for the `normal_x`, `normal_y`, and `normal_z` fields. This PR does not add support for covariance conversion.

Two new tests were added to cover point normal conversions. 